### PR TITLE
Assign codeowners to tm-cerebro

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @salemove/tm-cerebro


### PR DESCRIPTION
This PR adds CODEOWNERS file and assigns tm-cerebro as codeowners.